### PR TITLE
Update/update product repo get product by

### DIFF
--- a/src/main/java/ProductRepo.java
+++ b/src/main/java/ProductRepo.java
@@ -1,5 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class ProductRepo {
     private List<Product> products;
@@ -13,13 +14,13 @@ public class ProductRepo {
         return products;
     }
 
-    public Product getProductById(String id) {
+    public Optional<Product> getProductById(String id) {
         for (Product product : products) {
             if (product.id().equals(id)) {
-                return product;
+                return Optional.of(product);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     public Product addProduct(Product newProduct) {

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -1,5 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public class ShopService {
@@ -9,12 +10,12 @@ public class ShopService {
     public Order addOrder(List<String> productIds) {
         List<Product> products = new ArrayList<>();
         for (String productId : productIds) {
-            Product productToOrder = productRepo.getProductById(productId);
-            if (productToOrder == null) {
+            Optional<Product> productToOrder = productRepo.getProductById(productId);
+            if (productToOrder.isEmpty()) {
                 System.out.println("Product mit der Id: " + productId + " konnte nicht bestellt werden!");
                 return null;
             }
-            products.add(productToOrder);
+            products.add(productToOrder.get());
         }
 
         Order newOrder = new Order(UUID.randomUUID().toString(), products, OrderStatus.PROCESSING);

--- a/src/test/java/ProductRepoTest.java
+++ b/src/test/java/ProductRepoTest.java
@@ -43,7 +43,7 @@ class ProductRepoTest {
         //THEN
         Product expected = new Product("2", "Banane");
         assertEquals(actual, expected);
-        assertEquals(repo.getProductById("2"), expected);
+        assertTrue(repo.getProductById("2").isPresent());
     }
 
     @org.junit.jupiter.api.Test
@@ -55,6 +55,6 @@ class ProductRepoTest {
         repo.removeProduct("1");
 
         //THEN
-        assertNull(repo.getProductById("1"));
+        assertTrue(repo.getProductById("1").isEmpty());
     }
 }

--- a/src/test/java/ProductRepoTest.java
+++ b/src/test/java/ProductRepoTest.java
@@ -1,7 +1,4 @@
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -27,10 +24,10 @@ class ProductRepoTest {
         ProductRepo repo = new ProductRepo();
 
         //WHEN
-        Product actual = repo.getProductById("1");
+        Optional<Product> actual = repo.getProductById("1");
 
         //THEN
-        Product expected = new Product("1", "Apfel");
+        Optional<Product> expected = Optional.of(new Product("1", "Apfel"));
         assertEquals(actual, expected);
     }
 


### PR DESCRIPTION
I updated the method 'getProductById' in ProductRepo so that it returns an Optional<Product>.
After testing, the tests of 'removeProduct', 'addProduct' (in ProductRepo) and 'addOrder()' in ShopService failed, because they couldn't  handle the return type Optional<Product>. 
I fixed that and all tests passed!