### PR TITLE
Update/update order object timestamp

### DIFF
--- a/src/main/java/Order.java
+++ b/src/main/java/Order.java
@@ -1,11 +1,14 @@
 import lombok.With;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record Order(
         String id,
         List<Product> products,
 
-        @With OrderStatus orderStatus
+        @With OrderStatus orderStatus,
+
+        LocalDateTime timestamp
 ) {
 }

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -1,3 +1,6 @@
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -17,7 +20,11 @@ public class ShopService {
                 products.add(productToOrder.get());
         }
 
-        Order newOrder = new Order(UUID.randomUUID().toString(), products, OrderStatus.PROCESSING);
+        Instant instant = Instant.now();
+        ZoneId zoneId = ZoneId.systemDefault();
+        LocalDateTime timestamp = instant.atZone(zoneId).toLocalDateTime();
+
+        Order newOrder = new Order(UUID.randomUUID().toString(), products, OrderStatus.PROCESSING, timestamp);
 
         return orderRepo.addOrder(newOrder);
     }

--- a/src/test/java/OrderListRepoTest.java
+++ b/src/test/java/OrderListRepoTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,7 +14,7 @@ class OrderListRepoTest {
         OrderListRepo repo = new OrderListRepo();
 
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
         repo.addOrder(newOrder);
 
         //WHEN
@@ -22,7 +23,7 @@ class OrderListRepoTest {
         //THEN
         List<Order> expected = new ArrayList<>();
         Product product1 = new Product("1", "Apfel");
-        expected.add(new Order("1", List.of(product1), OrderStatus.PROCESSING));
+        expected.add(new Order("1", List.of(product1), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21)));
 
         assertEquals(actual, expected);
     }
@@ -33,7 +34,7 @@ class OrderListRepoTest {
         OrderListRepo repo = new OrderListRepo();
 
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
         repo.addOrder(newOrder);
 
         //WHEN
@@ -41,7 +42,7 @@ class OrderListRepoTest {
 
         //THEN
         Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
+        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
 
         assertEquals(actual, expected);
     }
@@ -51,14 +52,14 @@ class OrderListRepoTest {
         //GIVEN
         OrderListRepo repo = new OrderListRepo();
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
 
         //WHEN
         Order actual = repo.addOrder(newOrder);
 
         //THEN
         Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
+        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
         assertEquals(actual, expected);
         assertEquals(repo.getOrderById("1"), expected);
     }

--- a/src/test/java/OrderMapRepoTest.java
+++ b/src/test/java/OrderMapRepoTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,7 +14,7 @@ class OrderMapRepoTest {
         OrderMapRepo repo = new OrderMapRepo();
 
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
         repo.addOrder(newOrder);
 
         //WHEN
@@ -22,7 +23,7 @@ class OrderMapRepoTest {
         //THEN
         List<Order> expected = new ArrayList<>();
         Product product1 = new Product("1", "Apfel");
-        expected.add(new Order("1", List.of(product1), OrderStatus.PROCESSING));
+        expected.add(new Order("1", List.of(product1), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21)));
 
         assertEquals(actual, expected);
     }
@@ -33,7 +34,7 @@ class OrderMapRepoTest {
         OrderMapRepo repo = new OrderMapRepo();
 
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
         repo.addOrder(newOrder);
 
         //WHEN
@@ -41,7 +42,7 @@ class OrderMapRepoTest {
 
         //THEN
         Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
+        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
 
         assertEquals(actual, expected);
     }
@@ -51,14 +52,14 @@ class OrderMapRepoTest {
         //GIVEN
         OrderMapRepo repo = new OrderMapRepo();
         Product product = new Product("1", "Apfel");
-        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING);
+        Order newOrder = new Order("1", List.of(product), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
 
         //WHEN
         Order actual = repo.addOrder(newOrder);
 
         //THEN
         Product product1 = new Product("1", "Apfel");
-        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING);
+        Order expected = new Order("1", List.of(product1), OrderStatus.PROCESSING, LocalDateTime.of(2024,2, 13, 10, 21));
         assertEquals(actual, expected);
         assertEquals(repo.getOrderById("1"), expected);
     }

--- a/src/test/java/ShopServiceTest.java
+++ b/src/test/java/ShopServiceTest.java
@@ -1,5 +1,8 @@
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,12 +14,15 @@ class ShopServiceTest {
         //GIVEN
         ShopService shopService = new ShopService();
         List<String> productsIds = List.of("1");
+        Instant instant = Instant.now();
+        ZoneId zoneId = ZoneId.systemDefault();
+        LocalDateTime timestamp = instant.atZone(zoneId).toLocalDateTime();
 
         //WHEN
         Order actual = shopService.addOrder(productsIds);
 
         //THEN
-        Order expected = new Order("-1", List.of(new Product("1", "Apfel")), OrderStatus.PROCESSING);
+        Order expected = new Order("-1", List.of(new Product("1", "Apfel")), OrderStatus.PROCESSING, timestamp);
         assertEquals(expected.products(), actual.products());
         assertNotNull(expected.id());
     }
@@ -56,7 +62,7 @@ class ShopServiceTest {
     }
 
     @Test
-    void addOrder_whenProductNotExist_thenThrowProductNotFoundException() throws ProductNotFoundException{
+    void addOrder_whenProductNotExist_thenThrowProductNotFoundException() {
         //GIVEN
         ShopService shopService = new ShopService();
         List<String> productsIds = List.of("1", "2");


### PR DESCRIPTION
Added a field LocalDateTime timestamp to Order-object. Updated the method 'addOrder()' of ShopService to set the orders timestamp to current Date and Time for the local timezone using an' instant' at the system default timezone converted to 'LocalDateTime'. 
Add example timestamps to all tests that creates instances of 'Order' and wrote test for 'addOrder' of ShopService to ensure the correct timestamp of an generated Order.